### PR TITLE
bootcamps details links fix

### DIFF
--- a/coming-soon.html
+++ b/coming-soon.html
@@ -86,7 +86,7 @@
 							</div>
 						</div>
 
-					</li>  
+					</li>
 				</ul>
 			</section><a id="home_why_coding" class="in-page-link"></a>
 
@@ -271,7 +271,7 @@
 								<h4 class="uppercase bold">Competitive Coding Bootcamp</h4>
 								<span class="price">₹5,000</span>
 								<p class="lead">(8 lectures)</p>
-								<a class="btn btn-white btn-filled btn-lg" href="courses/bootcamps/competitiveprogramming.html">See Details</a>
+								<a class="btn btn-white btn-filled btn-lg" href="bootcamps/competitiveprogramming.html">See Details</a>
 								<ul>
 									<li>
 										<strong>Maths &amp; Number Theory</strong>
@@ -294,7 +294,7 @@
 								<h4 class="uppercase bold">Machine Learning Bootcamp </h4>
 								<span class="price">₹5,000</span>
 								<p class="lead">(8 Lectures)</p>
-								<a class="btn btn-white btn-filled btn-lg" href="courses/crux.html">See Details</a>
+								<a class="btn btn-white btn-filled btn-lg" href="bootcamps/machinelearning.html">See Details</a>
 								<ul>
 									<li>
 										<strong>Supervised Learning &amp; Algorithms</strong>
@@ -318,7 +318,7 @@
 								<h4 class="uppercase bold">Game Development Bootcamp</h4>
 								<span class="price">₹5,000</span>
 								<p class="lead">(8 Lectures)</p>
-								<a class="btn btn-white btn-lg btn-filled" href="courses/pandora.html">See Details</a>
+								<a class="btn btn-white btn-lg btn-filled" href="bootcamps/gamedevonline.html">See Details</a>
 								<ul>
 									<li>
 										<strong>Real Time Multiplayer Games</strong>

--- a/courses/algo++.html
+++ b/courses/algo++.html
@@ -54,6 +54,12 @@
 
 		   }
 
+       .button-tabs.vertical > .content {
+          padding-left: 3%;
+          max-width: 70%;
+          float: left;
+      }
+
    </style>
 		<script src="/js/fbpixel.js"></script>
 		<noscript>
@@ -103,7 +109,7 @@
 								Introducing our newest course on <strong>Algorithms and Data Structures(in C++)</strong> starting this summer. The course is for all those who are looking forward to sit for internships and placements in August. The course will involve rigorous practice of questions based on <strong>Sorting, Searching, Greedy Algorithms, Divide and Conquer Algorithms, Dynamic Programming</strong> along with comprehensive revision of data structures like linked-lists, Trees, Graphs, Heaps, Hashing etc. The course will help you become smarter with solutions and ace your programming interviews.
                                 <br>
                                 The course will end by mid-July.<br><br>
-                                 
+
                                 <a class="btn btn-lg btn-filled" href="#course-register">Register Now</a>
                             </p>
 		                </div>

--- a/courses/crux.html
+++ b/courses/crux.html
@@ -45,6 +45,12 @@
 					background-size: cover;
 
 			}
+
+			.button-tabs.vertical > .content {
+					padding-left: 3%;
+					max-width: 70%;
+					float: left;
+			}
 			</style>
 	<script src="/js/fbpixel.js"></script>
 	<noscript>
@@ -98,7 +104,7 @@
 					<p class="lead">
                        Begin your career in software development with the introduction to Data Structures and Algorithms in Java. Java, an Object Oriented Programming is one of the most sought after programming language and is the foundation of the Android operating system. Java is a perfect computer language for being competitive in today’s industry requirements.Designed for beginners, CRUX is a hands on course where we focus on developing core programming concepts and equip you to code solutions for complex problems.
 					</p>
-                    
+
                         <br><br>
                         <a class="btn btn-lg btn-filled" href="#course-register">
                           Register Now</a>
@@ -407,8 +413,8 @@
                         <strong>11th June </strong>at Greater Noida<br>
 
 
-        
-						
+
+
 					</p>
 					<div class="overflow-hidden mb32 mb-xs-24">
 						<i class="icon pull-left et-line-search icon-sm"></i>
@@ -457,7 +463,7 @@
 	<!-- SECTION: Testimonials -->
 	<a id="course-testimonials" class="in-page-link"></a>
 	<section class="bg-secondary">
-        
+
 		<div class="container">
 			<div class="row">
 				<div class="col-sm-8 col-sm-offset-2 text-center">

--- a/courses/elixir.html
+++ b/courses/elixir.html
@@ -46,6 +46,12 @@
 
            }
 
+           .button-tabs.vertical > .content {
+          padding-left: 3%;
+          max-width: 70%;
+          float: left;
+      }
+
    </style>
 		<script src="/js/fbpixel.js"></script>
 		<noscript>
@@ -160,7 +166,7 @@
       									<h5 class="uppercase">HTML/CSS</h5>
       									<hr>
       								<p>
-                        The building blocks of web pages – HTML and CSS. Learn how to use the latest HTML5 technologies along with CSS3 stylesheets to create amazing and responsive web sites that catch the eye of the viewer. We will also cover UI design patterns  like – 
+                        The building blocks of web pages – HTML and CSS. Learn how to use the latest HTML5 technologies along with CSS3 stylesheets to create amazing and responsive web sites that catch the eye of the viewer. We will also cover UI design patterns  like –
 
       									</p>
       									<p>
@@ -183,7 +189,7 @@
       									<hr>
       									<p>
       										 HTML and CSS brings the content and design together, while Javascript is at the heart of all action. Learn to act on events like ‘clicks’, ‘hovers’ and ‘drag and drop’. Javascript is one of the most powerful and ubiquitious languages in modern software development, and we will cover the innards of Javascript in depth including –
-                             
+                            
       									</p>
       									<p>
       										Lectures 3-10<br>
@@ -203,7 +209,7 @@
       								<div class="tab-content">
       									<h5 class="uppercase">UNIX and Git </h5>
       									<hr>
-      									<p> 
+      									<p>
       										Before we move on to backend development, we will briefly touch upon usage of Unix based systems. More than 80% of the world’s servers are hosted on Linux machines, and any web backend developer has to learn basic DevOps and SysAdmin skills to manage a Linux OS. Also Git, the most commonly used version control system, is one of the most helpful tool required to work on large projects or in collaborative environments
 
       									</p>
@@ -226,7 +232,7 @@
       									<h5 class="uppercase">NODEJS</h5>
       									<hr>
       									<p>
-      										Javascript is not just only on the frontend, but a potent force on the server too. Built by Ryan Dahl in 2009 as a platform to run JS code on bare metal, NodeJS is right now the fastest growing ecosystem. We will learn – 
+      										Javascript is not just only on the frontend, but a potent force on the server too. Built by Ryan Dahl in 2009 as a platform to run JS code on bare metal, NodeJS is right now the fastest growing ecosystem. We will learn –
       									</p>
       									<p>
       										Lecture 12-16<br>
@@ -255,7 +261,7 @@
                                           2. MySQL<br>
                                           3. Using ORMs like Sequelize<br>
                                           4.MongoDB<br>
-                                          
+
                       </p>
                     </div>
                   </li>


### PR DESCRIPTION
This is in reference to issue #31. The bootcamps page had wrong links assosiated with the get details button. The same has been fixed.