### PR TITLE
Added basic structure for Events Page

### DIFF
--- a/events/index.html
+++ b/events/index.html
@@ -146,7 +146,7 @@
 					</div>
 
 					<div class="col-lg-4 no-pad">
-						<div class="pricing-table pt-2 text-center" style="padding:50px 20px;">
+						<div class="pricing-table pt-2 text-center" style="padding:40px 20px;">
 							<img alt="C++ course logo" class="course eventlogo" src="https://scontent.fdel1-1.fna.fbcdn.net/v/t1.0-9/18556333_1896604110557923_199183566741658288_n.jpg?oh=d3538ec834e90cc1659cec0b83115dd8&oe=59B6AC18">
 							<h4 class="uppercase bold">Coders' Admission & Scholarship Test</h4>
 							<p class="lead">MAY 30</p>
@@ -160,7 +160,7 @@
 					</div>
 
 					<div class="col-lg-4 no-pad">
-						<div class="pricing-table pt-2 text-center boxed" style="padding:50px 20px;">
+						<div class="pricing-table pt-2 text-center boxed" style="padding:40px 20px;">
 							<img alt="C++ course logo" class="course" src="https://scontent.fdel1-1.fna.fbcdn.net/v/t1.0-9/18010116_1882476711970663_3462392790741446665_n.jpg?oh=09626f35cf293b89633870856554573e&oe=59C25B4B">
 							<h4 class="uppercase bold">Competitive Programming Summer Bootcamp</h4>
 							<p class="lead">JUN 1</p>
@@ -174,7 +174,7 @@
 				</div>
 				<div class="row">
 					<div class="col-lg-4 no-pad">
-						<div class="pricing-table pt-2 text-center" style="padding:50px 20px;">
+						<div class="pricing-table pt-2 text-center" style="padding:40px 20px;">
 							<img alt="C++ course logo" class="course" src="https://scontent.fdel1-1.fna.fbcdn.net/v/t1.0-9/18199360_1888861147998886_5307169787776343524_n.jpg?oh=4b466b6d6e0ed858e9d89e69db2d3af8&oe=59AD4DE7">
 							<h4 class="uppercase bold">Perceptron - Machine Learning Bootcamp</h4>
 							<p class="lead">JUN 4</p>
@@ -187,7 +187,7 @@
 					</div>
 
 					<div class="col-lg-4 no-pad">
-						<div class="pricing-table pt-2 text-center boxed" style="padding:50px 20px;">
+						<div class="pricing-table pt-2 text-center boxed" style="padding:40px 20px;">
 							<img alt="C++ course logo" class="course" src="https://scontent.fdel1-1.fna.fbcdn.net/v/t1.0-9/17796850_1875309089354092_3834854144484622142_n.jpg?oh=b0ba1539d0aff0974b132671db212986&oe=59B4A6E4">
 							<h4 class="uppercase bold">Summer with Algorithms</h4>
 							<p class="lead">JUN 10</p>
@@ -201,7 +201,7 @@
 					</div>
 
 					<div class="col-lg-4 no-pad">
-						<div class="pricing-table pt-2 text-center oldevent" style="padding:50px 20px;">
+						<div class="pricing-table pt-2 text-center oldevent" style="padding:40px 20px;">
 							<img alt="C++ course logo" class="course" src="https://scontent.fdel1-1.fna.fbcdn.net/v/t1.0-9/18157372_1886508048234196_1001625968942495630_n.jpg?oh=1a07e47e7c1b9e9a8049e609790998a1&oe=59BC566F">
 							<h4 class="uppercase bold">Google I/O Extended</h4>
 							<p class="lead">MAY 17</p>
@@ -210,7 +210,7 @@
 								<li style="line-height:30px;">
 									Coding Blocks is pleased to host Google I/0 Extended 2017, and we are inviting student and developer community for this a night filled with amazing experiences.</li>
 							</ul>
-							<div class="oldoverlay" style="padding:50px 20px;top:0%;">
+							<div class="oldoverlay" style="padding:40px 20px;top:0%;">
 								<div class="uppercase bold oldtext">Past Event</h4>
 								</div>
 							</div>

--- a/events/index.html
+++ b/events/index.html
@@ -1,0 +1,265 @@
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+	<meta charset="utf-8">
+	<title>Events | Coding Blocks</title>
+	<meta name="description" content="Find upcoming and past events by codingblocks." />
+	<meta name="keywords" content="java lectures, coding lectures, programming classes, coding institute delhi, java training delhi, learn c++, learn nodejs, coding blocks, become ninja developer" />
+
+	<meta name="viewport" content="width=device-width, initial-scale=1.0">
+	<!--<link href="../css/pe-icon-7-stroke.css" rel="stylesheet" type="text/css" media="all">-->
+	<!--<link href="../css/et-line-icons.css" rel="stylesheet" type="text/css" media="all">-->
+	<link href="../css/font-awesome.min.css" rel="stylesheet" type="text/css" media="all">
+	<link href="../css/themify-icons.css" rel="stylesheet" type="text/css" media="all" />
+	<link href="../css/bootstrap.css" rel="stylesheet" type="text/css" media="all" />
+	<link href="../css/flexslider.css" rel="stylesheet" type="text/css" media="all" />
+	<link href="../css/theme-fire.css" rel="stylesheet" type="text/css" media="all" />
+	<link href="../css/custom.css" rel="stylesheet" type="text/css" media="all" />
+
+
+	<!-- Icons and manifest -->
+	<link rel="apple-touch-icon" sizes="57x57" href="../icons/apple-icon-57x57.png">
+	<link rel="apple-touch-icon" sizes="60x60" href="../icons/apple-icon-60x60.png">
+	<link rel="apple-touch-icon" sizes="72x72" href="../icons/apple-icon-72x72.png">
+	<link rel="apple-touch-icon" sizes="76x76" href="../icons/apple-icon-76x76.png">
+	<link rel="apple-touch-icon" sizes="114x114" href="../icons/apple-icon-114x114.png">
+	<link rel="apple-touch-icon" sizes="120x120" href="../icons/apple-icon-120x120.png">
+	<link rel="apple-touch-icon" sizes="144x144" href="../icons/apple-icon-144x144.png">
+	<link rel="apple-touch-icon" sizes="152x152" href="../icons/apple-icon-152x152.png">
+	<link rel="apple-touch-icon" sizes="180x180" href="../icons/apple-icon-180x180.png">
+	<link rel="icon" type="image/png" sizes="192x192" href="../icons/android-icon-192x192.png">
+	<link rel="icon" type="image/png" sizes="32x32" href="../icons/favicon-32x32.png">
+	<link rel="icon" type="image/png" sizes="96x96" href="../icons/favicon-96x96.png">
+	<link rel="icon" type="image/png" sizes="16x16" href="../icons/favicon-16x16.png">
+	<link rel="manifest" href="/manifest.json">
+	<meta name="msapplication-TileColor" content="#fc4f4f">
+	<meta name="msapplication-TileImage" content="../icons/ms-icon-144x144.png">
+	<meta name="mobile-web-app-capable" content="yes">
+	<meta name="theme-color" content="#fc4f4f">
+	<style>
+		.flex-container {
+			display: -webkit-flex;
+			display: flex;
+			-webkit-flex-wrap: nowrap;
+			flex-wrap: nowrap;
+			justify-content: center;
+			-webkit-justify-content: center;
+		}
+
+		.flex-item {
+			max-width: 100%;
+			max-height: 100%;
+		}
+
+		.no-pad {
+			padding: 0px 0px!important;
+		}
+
+		.colw90 {
+			width: 90%;
+			margin-left: 5%;
+			margin-right: 5%;
+		}
+
+		.eventlogo {
+			height: 170px!important;
+		}
+
+		.oldevent {
+			-webkit-filter: grayscale(1);
+		}
+
+		.oldevent:hover .oldoverlay {
+			opacity: 1;
+		}
+
+		.oldtext {
+			position: absolute;
+			top: 50%;
+			left: 50%;
+			transform: translate(-50%, -50%);
+			-ms-transform: translate(-50%, -50%);
+			font-weight: 600 !important;
+			font-size: 24px;
+			line-height: 32px;
+			font-family: "Raleway", "Helvetica Neue", Helvetica, Arial, sans-serif;
+			text-transform: uppercase;
+			letter-spacing: 3px;
+		}
+
+		.oldoverlay {
+			position: absolute;
+			top: 0;
+			bottom: 0;
+			left: 0;
+			right: 0;
+			height: 100%;
+			width: 100%;
+			opacity: 0;
+			transition: .5s ease;
+			background-color: rgba(256, 256, 256, 0.8);
+		}
+	</style>
+
+	<script src="/js/jquery.min.js"></script>
+	<script src="/js/bootstrap.min.js"></script>
+	<script src="/js/fbpixel.js"></script>
+</head>
+
+<body class="scroll-assist">
+	<!-- NAVBAR -->
+
+	<div class="nav-container">
+
+	</div>
+	<div class="main-container">
+
+
+		<!-- SECTION: Courses -->
+		<a id="upcoming_events" class="in-page-link"></a>
+		<section>
+			<div class="container">
+				<div class="row">
+					<div class="col-sm-12 text-center">
+						<h3 class="uppercase mb16">EVENTS</h3>
+						<!--<p class="lead mb64">
+								Courses for all stages, with equal focus on theory and implementation
+							</p>-->
+					</div>
+				</div>
+
+				<div class="row">
+
+					<div class="col-lg-4 no-pad">
+						<div class="pricing-table pt-2 text-center boxed" style="padding:40px 20px;">
+							<img alt="C++ course logo" class="course eventlogo" src="https://scontent.fdel1-1.fna.fbcdn.net/v/t1.0-9/18581572_1896695767215424_863391401195014128_n.jpg?oh=961dba0ef0d49d595fa543c208cb7101&oe=59A68489">
+							<h4 class="uppercase bold">Dynamic Programming Webinar</h4>
+							<p class="lead">MAY 27</p>
+							<a class="btn btn-white btn-filled btn-lg" href="https://www.facebook.com/events/259546851118557/">See Details</a>
+							<ul>
+								<li style="line-height:30px;">
+									Inviting all coders for a free webinar on introduction to Dynamic Programming and Its Applications to be taken by Prateek Bhayia from Coding Blocks. The webinar will cover some of the interesting and challenging questions as well. The webinar is free
+									for all those who register. </li>
+							</ul>
+						</div>
+					</div>
+
+					<div class="col-lg-4 no-pad">
+						<div class="pricing-table pt-2 text-center" style="padding:50px 20px;">
+							<img alt="C++ course logo" class="course eventlogo" src="https://scontent.fdel1-1.fna.fbcdn.net/v/t1.0-9/18556333_1896604110557923_199183566741658288_n.jpg?oh=d3538ec834e90cc1659cec0b83115dd8&oe=59B6AC18">
+							<h4 class="uppercase bold">Coders' Admission & Scholarship Test</h4>
+							<p class="lead">MAY 30</p>
+							<a class="btn btn-white btn-filled btn-lg" href="https://www.facebook.com/events/1490469230997871/">See Details</a>
+							<ul>
+								<li style="line-height:30px;">
+									Coding Blocks is pleased to announce the Coders' Admission & Scholarship Test (CAST) for our Gretaer Noida Center. Scholarships of up to 75% off the total price are up for grabs for our foundation courses. CAST will be an online aptitude test to check
+									your logical ability.</li>
+							</ul>
+						</div>
+					</div>
+
+					<div class="col-lg-4 no-pad">
+						<div class="pricing-table pt-2 text-center boxed" style="padding:50px 20px;">
+							<img alt="C++ course logo" class="course" src="https://scontent.fdel1-1.fna.fbcdn.net/v/t1.0-9/18010116_1882476711970663_3462392790741446665_n.jpg?oh=09626f35cf293b89633870856554573e&oe=59C25B4B">
+							<h4 class="uppercase bold">Competitive Programming Summer Bootcamp</h4>
+							<p class="lead">JUN 1</p>
+							<a class="btn btn-white btn-filled btn-lg" href="https://www.facebook.com/events/">See Details</a>
+							<ul>
+								<li style="line-height:30px;">
+									Hone your CP skills by attending 1-week Competitive Programming Bootcamp. Learn new concepts by solving over 150 complex problems of varying difficulty level and brighten up you chances of getting selected in APAC and ACM-ICPC.</li>
+							</ul>
+						</div>
+					</div>
+				</div>
+				<div class="row">
+					<div class="col-lg-4 no-pad">
+						<div class="pricing-table pt-2 text-center" style="padding:50px 20px;">
+							<img alt="C++ course logo" class="course" src="https://scontent.fdel1-1.fna.fbcdn.net/v/t1.0-9/18199360_1888861147998886_5307169787776343524_n.jpg?oh=4b466b6d6e0ed858e9d89e69db2d3af8&oe=59AD4DE7">
+							<h4 class="uppercase bold">Perceptron - Machine Learning Bootcamp</h4>
+							<p class="lead">JUN 4</p>
+							<a class="btn btn-white btn-filled btn-lg" href="https://www.facebook.com/events/387648074968504/">See Details</a>
+							<ul>
+								<li style="line-height:30px;">
+									Coding Blocks is pleased to announce - Perceptron - Machine Learning Course and Bootcamp for Summers. This will be hands on course on Machine Learning, you will learn to implement algorithms from scratch in Python and build your own cool projects.</li>
+							</ul>
+						</div>
+					</div>
+
+					<div class="col-lg-4 no-pad">
+						<div class="pricing-table pt-2 text-center boxed" style="padding:50px 20px;">
+							<img alt="C++ course logo" class="course" src="https://scontent.fdel1-1.fna.fbcdn.net/v/t1.0-9/17796850_1875309089354092_3834854144484622142_n.jpg?oh=b0ba1539d0aff0974b132671db212986&oe=59B4A6E4">
+							<h4 class="uppercase bold">Summer with Algorithms</h4>
+							<p class="lead">JUN 10</p>
+							<a class="btn btn-white btn-filled btn-lg" href="https://www.facebook.com/events/739154826243800/">See Details</a>
+							<ul>
+								<li style="line-height:30px;">
+									Introducing our newest course on Algorithms and Data Structures(in C++) starting this summer. The course is for all those who are looking forward to sit for internships and placements in August. The course will involve questions based on Sorting, Searching,
+									Greedy Algorithms, Divide and Conquer and much more.</li>
+							</ul>
+						</div>
+					</div>
+
+					<div class="col-lg-4 no-pad">
+						<div class="pricing-table pt-2 text-center oldevent" style="padding:50px 20px;">
+							<img alt="C++ course logo" class="course" src="https://scontent.fdel1-1.fna.fbcdn.net/v/t1.0-9/18157372_1886508048234196_1001625968942495630_n.jpg?oh=1a07e47e7c1b9e9a8049e609790998a1&oe=59BC566F">
+							<h4 class="uppercase bold">Google I/O Extended</h4>
+							<p class="lead">MAY 17</p>
+							<a class="btn btn-white btn-filled btn-lg" href="https://www.facebook.com/events/289979278095123/">See Details</a>
+							<ul>
+								<li style="line-height:30px;">
+									Coding Blocks is pleased to host Google I/0 Extended 2017, and we are inviting student and developer community for this a night filled with amazing experiences.</li>
+							</ul>
+							<div class="oldoverlay" style="padding:50px 20px;top:0%;">
+								<div class="uppercase bold oldtext">Past Event</h4>
+								</div>
+							</div>
+
+						</div>
+
+					</div>
+				</div>
+		</section>
+
+		<!-- SECTION : Map-->
+		<a id="home_map" class="in-page-link"></a>
+		<section class="image-square right">
+			<div class="map-container">
+				<div class="col-md-6 p0 image">
+					<div class="map-canvas" data-address="
+							Red Fort, New Delhi[nomarker];
+							3, Pocket 3, Sector 11, Dwarka;
+							47, Nishant Kunj, New Delhi;
+							1090, Block C, Sushant Lok I;
+							Knowledge Park I, Greater Noida, Uttar Pradesh 201310" data-marker-title="Coding Blocks" data-map-zoom="10" data-maps-api-key="AIzaSyCtSz4b43fPFC1kT90-x52A3ECJfBnHvN8" data-map-style="[{&quot;stylers&quot;:[{&quot;hue&quot;:&quot;#dd0d0d&quot;}]},{&quot;featureType&quot;:&quot;road&quot;,&quot;elementType&quot;:&quot;labels&quot;,&quot;stylers&quot;:[{&quot;visibility&quot;:&quot;off&quot;}]},{&quot;featureType&quot;:&quot;road&quot;,&quot;elementType&quot;:&quot;geometry&quot;,&quot;stylers&quot;:[{&quot;lightness&quot;:100},{&quot;visibility&quot;:&quot;simplified&quot;}]}]"></div>
+				</div>
+			</div>
+			<div class="col-md-6 content">
+				<form id="message-form" class="form-email" data-success="Thanks for your submission, we will be in touch shortly." data-error="Please fill all fields correctly.">
+					<h6 class="uppercase text-center">Send A Message</h6>
+					<input class="validate-required" name="name" placeholder="Your Name" type="text">
+					<input class="validate-required validate-email" name="email" placeholder="Email Address" type="text">
+					<input class="validate-required" name="subject" placeholder="Subject" type="text">
+					<textarea class="validate-required" name="message" rows="4" placeholder="Message"></textarea>
+					<button type="submit">Send Message</button>
+				</form>
+			</div>
+		</section>
+
+		<!-- FOOTER -->
+		<div class="footer">
+
+		</div>
+
+		</div>
+
+		<script src="js/twitterfetcher.min.js"></script>
+		<script src="js/flexslider.min.js"></script>
+		<script src="js/smooth-scroll.min.js"></script>
+		<script async defer src="js/parallax.js"></script>
+		<script src="js/scripts.js"></script>
+		<script src="js/componentloader.js"></script>
+
+</body>
+
+</html>


### PR DESCRIPTION
I have added basic structure for events page. img sources from facebook and see more linked with facebook event. Past event overlay and greyscale for old events added. 
BOSS-Issue: https://github.com/coding-blocks/coding-blocks.github.io/issues/63
## Basic Struture
![image](https://cloud.githubusercontent.com/assets/22571395/26274168/dbefa0da-3d60-11e7-8cad-825266b4423b.png)

## Old Event Greyscale
![image](https://cloud.githubusercontent.com/assets/22571395/26274171/e8195108-3d60-11e7-9f7b-6afbb9531fa1.png)

## Old Event Overlay
![image](https://cloud.githubusercontent.com/assets/22571395/26274172/f6cec34a-3d60-11e7-8bee-b404d8db1779.png)
